### PR TITLE
Fix advanced_security_options example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.1 (September 17, 2020)
+
+FIXES:
+
+* Fix `advanced_security_options` example. In order to use `master_user_arn`, the value for `internal_user_database_enabled` must be set to `false`.
+
 ## 0.5.0 (September 3, 2020)
 
 ENHANCEMENTS:

--- a/examples/advanced_security_options_master_user_arn/README.md
+++ b/examples/advanced_security_options_master_user_arn/README.md
@@ -18,7 +18,6 @@ module "aws_es" {
 
   advanced_security_options = {
     enabled                        = true
-    internal_user_database_enabled = true
     master_user_options = {
       master_user_arn = "arn:aws:iam::123456789101:user/lgallard"
     }

--- a/examples/advanced_security_options_master_user_arn/main.tf
+++ b/examples/advanced_security_options_master_user_arn/main.tf
@@ -14,8 +14,7 @@ module "aws_es" {
   }
 
   advanced_security_options = {
-    enabled                        = true
-    internal_user_database_enabled = true
+    enabled = true
     master_user_options = {
       master_user_arn = "arn:aws:iam::123456789101:user/lgallard"
     }


### PR DESCRIPTION
In order to use `master_user_arn`, the value for `internal_user_database_enabled` must be set to `false`.

It fixes #15 
