### PR TITLE
Add retention configuration variable for Cloudwatch log group

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ module "aws_es" {
 | log\_publishing\_options\_cloudwatch\_log\_group\_arn | iARN of the Cloudwatch log group to which log needs to be published | `string` | `""` | no |
 | log\_publishing\_options\_enabled | Specifies whether given log publishing option is enabled or not | `bool` | `true` | no |
 | log\_publishing\_options\_log\_type | A type of Elasticsearch log. Valid values: INDEX\_SLOW\_LOGS, SEARCH\_SLOW\_LOGS, ES\_APPLICATION\_LOGS | `string` | `"INDEX_SLOW_LOGS"` | no |
+| log\_publishing\_options\_retention | Retention in days for the created Cloudwatch log group | `number` | `90` | no |
 | node\_to\_node\_encryption | Node-to-node encryption options | `map` | `{}` | no |
 | node\_to\_node\_encryption\_enabled | Whether to enable node-to-node encryption | `bool` | `true` | no |
 | snapshot\_options | Snapshot related options | `map` | `{}` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,7 @@
 resource "aws_cloudwatch_log_group" "es_cloudwatch_log_group" {
   name = "${var.domain_name}-log_group"
   tags = var.tags
+  retention_in_days = var.log_publishing_options_retention
 }
 
 resource "aws_cloudwatch_log_resource_policy" "es_aws_cloudwatch_log_resource_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -268,6 +268,13 @@ variable "log_publishing_options_enabled" {
   default     = true
 }
 
+variable "log_publishing_options_retention" {
+  description = "Retention in days for the created Cloudwatch log group"
+  type        = number
+  default     = 90
+}
+
+
 # cognito_options  
 variable "cognito_options" {
   description = "Options for Amazon Cognito Authentication for Kibana"


### PR DESCRIPTION
This commits introduces a new, non-required variable to be able to configure retention in
days for the Cloudwatch log group that is created.