### PR TITLE
Fix master_user_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.1 (January 24, 2021)
+
+FIXES:
+
+* Fix `master_user_name` reference in locals (thanks @rafaelmariotti)
+
 ## 0.7.0 (January 8, 2021)
 
 ENHANCEMENTS:

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ module "aws_es" {
   }
 
 ```
-
 ## Requirements
 
 | Name | Version |

--- a/main.tf
+++ b/main.tf
@@ -148,7 +148,7 @@ locals {
   # Create subblock master_user_options
   master_user_options = lookup(var.advanced_security_options, "master_user_options", null) != null ? lookup(var.advanced_security_options, "master_user_options") : {
     master_user_arn      = var.advanced_security_options_internal_user_database_enabled == false ? var.advanced_security_options_master_user_arn : null
-    master_user_username = var.advanced_security_options_internal_user_database_enabled == true ? var.advanced_security_options_master_user_username : null
+    master_user_name     = var.advanced_security_options_internal_user_database_enabled == true ? var.advanced_security_options_master_user_username : null
     master_user_password = var.advanced_security_options_internal_user_database_enabled == true ? var.advanced_security_options_master_user_password : null
   }
 


### PR DESCRIPTION
Fix `master_user_name` reference in locals (thanks @rafaelmariotti)

It fixes #31 