### PR TITLE
Ability to have random master password

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ No modules.
 | <a name="input_advanced_security_options_master_user_arn"></a> [advanced\_security\_options\_master\_user\_arn](#input\_advanced\_security\_options\_master\_user\_arn) | ARN for the master user. Only specify if `internal_user_database_enabled` is not set or set to `false`) | `string` | `null` | no |
 | <a name="input_advanced_security_options_master_user_password"></a> [advanced\_security\_options\_master\_user\_password](#input\_advanced\_security\_options\_master\_user\_password) | The master user's password, which is stored in the Amazon Elasticsearch Service domain's internal database. Only specify if `internal_user_database_enabled` is set to `true`. | `string` | `null` | no |
 | <a name="input_advanced_security_options_master_user_username"></a> [advanced\_security\_options\_master\_user\_username](#input\_advanced\_security\_options\_master\_user\_username) | The master user's username, which is stored in the Amazon Elasticsearch Service domain's internal database. Only specify if `internal_user_database_enabled` is set to `true`. | `string` | `null` | no |
+| <a name="input_advanced_security_options_create_random_master_password"></a> [advanced\_security\_options\_create\_random\_master\_password](#input\_advanced\_security\_options\_create\_random\_master\_password) | Whether to create random master password for Elasticsearch master user | `bool` | `false` | no |
+| <a name="input_advanced_security_options_random_master_password_length"></a> [advanced\_security\_options\_random\_master\_password\_length](#advanced\_security\_options\_random\_master\_password\_length) | Length of random master password to create | `number` | `16` | no |
 | <a name="input_cloudwatch_log_enabled"></a> [cloudwatch\_log\_enabled](#input\_cloudwatch\_log\_enabled) | Change to false to avoid deploying any Cloudwatch Logs resources | `bool` | `true` | no |
 | <a name="input_cluster_config"></a> [cluster\_config](#input\_cluster\_config) | Cluster configuration of the domain | `any` | `{}` | no |
 | <a name="input_cluster_config_availability_zone_count"></a> [cluster\_config\_availability\_zone\_count](#input\_cluster\_config\_availability\_zone\_count) | Number of Availability Zones for the domain to use with | `number` | `3` | no |
@@ -213,6 +215,8 @@ No modules.
 | <a name="output_arn"></a> [arn](#output\_arn) | Amazon Resource Name (ARN) of the domain |
 | <a name="output_domain_id"></a> [domain\_id](#output\_domain\_id) | Unique identifier for the domain |
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | Domain-specific endpoint used to submit index, search, and data upload requests |
+| <a name="master_username"></a> [master_username](#master\_username) | Master username (if internal database master user enabled) |
+| <a name="master_password"></a> [master_password](#master\_password) | Master password (if internal database master user enabled) |
 | <a name="output_kibana_endpoint"></a> [kibana\_endpoint](#output\_kibana\_endpoint) | Domain-specific endpoint for kibana without https scheme |
 | <a name="output_vpc_options_availability_zones"></a> [vpc\_options\_availability\_zones](#output\_vpc\_options\_availability\_zones) | If the domain was created inside a VPC, the names of the availability zones the configured subnet\_ids were created inside |
 | <a name="output_vpc_options_vpc_id"></a> [vpc\_options\_vpc\_id](#output\_vpc\_options\_vpc\_id) | If the domain was created inside a VPC, the ID of the VPC |

--- a/main.tf
+++ b/main.tf
@@ -161,10 +161,14 @@ locals {
   # advanced_security_options
   # Create subblock master_user_options
   create_random_master_password = var.advanced_security_options_enabled && var.advanced_security_options_internal_user_database_enabled && var.advanced_security_options_create_random_master_password
+  master_user_arn      = var.advanced_security_options_internal_user_database_enabled == false ? var.advanced_security_options_master_user_arn : null
+  master_user_name     = var.advanced_security_options_internal_user_database_enabled == true ? var.advanced_security_options_master_user_username : null
+  master_user_password = local.create_random_master_password == true ? random_password.master_password[0].result : var.advanced_security_options_master_user_password
+
   master_user_options = lookup(var.advanced_security_options, "master_user_options", null) != null ? lookup(var.advanced_security_options, "master_user_options") : {
-    master_user_arn      = var.advanced_security_options_internal_user_database_enabled == false ? var.advanced_security_options_master_user_arn : null
-    master_user_name     = var.advanced_security_options_internal_user_database_enabled == true ? var.advanced_security_options_master_user_username : null
-    master_user_password = local.create_random_master_password == true ? random_password.master_password[0].result : var.advanced_security_options_master_user_password
+    master_user_arn      = local.master_user_arn
+    master_user_name     = local.master_user_name
+    master_user_password = local.master_user_password
   }
 
   # If advanced_security_options is provided, build an advanced_security_options using the default values

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,12 +20,12 @@ output "kibana_endpoint" {
 
 output "master_username" {
   description = "Master username"
-  value       = lookup(local.master_user_options, "master_user_name")
+  value       = local.master_user_name
 }
 
 output "master_password" {
   description = "Master password"
-  value       = lookup(local.master_user_options, "master_user_password")
+  value       = local.master_user_password
   sensitive = true
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,17 @@ output "kibana_endpoint" {
   value       = join("", aws_elasticsearch_domain.es_domain.*.kibana_endpoint)
 }
 
+output "master_username" {
+  description = "Master username"
+  value       = lookup(local.master_user_options, "master_user_name")
+}
+
+output "master_password" {
+  description = "Master password"
+  value       = lookup(local.master_user_options, "master_user_password")
+  sensitive = true
+}
+
 output "vpc_options_availability_zones" {
   description = "If the domain was created inside a VPC, the names of the availability zones the configured subnet_ids were created inside"
   value       = var.enabled ? (length(aws_elasticsearch_domain.es_domain[0].vpc_options) > 0 ? aws_elasticsearch_domain.es_domain[0].vpc_options.0.availability_zones : []) : []

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,18 @@ variable "advanced_security_options_master_user_password" {
   default     = null
 }
 
+variable "advanced_security_options_create_random_master_password" {
+  description = "Whether to create random master password for Elasticsearch master user"
+  type        = bool
+  default     = false
+}
+
+variable "advanced_security_options_random_master_password_length" {
+  description = "Length of random master password to create"
+  type        = number
+  default     = 16
+}
+
 # Domain endpoint options
 variable "domain_endpoint_options" {
   description = "Domain endpoint HTTP(S) related options."

--- a/versions.tf
+++ b/versions.tf
@@ -3,5 +3,6 @@ terraform {
 
   required_providers {
     aws = ">= 3.35.0"
+    random = ">=3.1.2"
   }
 }


### PR DESCRIPTION
**What this PR do:**
This PR adds feature to generate random master password and puts it to module output.

**Why we need this:** 
We are using this module with terragrunt. Unfortunately terragrunt doesn't have tools for generate randoms passwords and put it it some storage ( Vault in our case).
I made this like [amazon rds module](https://registry.terraform.io/modules/terraform-aws-modules/rds/aws/latest) - this module have a same functional.